### PR TITLE
fix: space in front of numeric (0-04-053)

### DIFF
--- a/BUFRCREX_TableB_en_04.csv
+++ b/BUFRCREX_TableB_en_04.csv
@@ -25,7 +25,7 @@ ClassNo,ClassName_en,FXY,ElementName_en,Note_en,BUFR_Unit,BUFR_Scale,BUFR_Refere
 04,Location (time),004043,Day of the year,,d,0,0,9,d,0,3,Operational
 04,Location (time),004051,Principal time of daily reading of maximum temperature,,h,0,0,5,h,0,2,Operational
 04,Location (time),004052,Principal time of daily reading of minimum temperature,,h,0,0,5,h,0,2,Operational
-04,Location (time),004053,Number of days with precipitation equal to or more than 1 mm,,Numeric,0,0, 6,Numeric,0,2,Operational
+04,Location (time),004053,Number of days with precipitation equal to or more than 1 mm,,Numeric,0,0,6,Numeric,0,2,Operational
 04,Location (time),004059,Times of observation used to compute the reported mean values,,Flag table,0,0,6,Flag table,0,2,Operational
 04,Location (time),004065,Short time increment,,min,0,-128,8,min,0,2,Operational
 04,Location (time),004066,Short time increment,,s,0,-128,8,s,0,2,Operational


### PR DESCRIPTION
An extra space in front of the BUFR_DataWidth_Bits of 0-04-053
descriptor. This could fail a parser that expects and integer for
data width.

Thanks to @luizirber who found that while parsing this table with Rust.