### PR TITLE
Adds a note relating to the use 0-07-007 element descriptor in the context of template 3-11-014 (drifting balloons)

### DIFF
--- a/BUFR_TableD_en_11.csv
+++ b/BUFR_TableD_en_11.csv
@@ -249,7 +249,7 @@ Category,CategoryOfSequences_en,FXY1,Title_en,SubTitle_en,FXY2,ElementName_en,El
 11,Single level report sequences (conventional data),311014,(Template for drifting balloon systems),,301011,"Year, month, day",,,,Operational
 11,Single level report sequences (conventional data),311014,(Template for drifting balloon systems),,301013,"Hour, minute, second",,,,Operational
 11,Single level report sequences (conventional data),311014,(Template for drifting balloon systems),,301021,Latitude/longitude (high accuracy),,,,Operational
-11,Single level report sequences (conventional data),311014,(Template for drifting balloon systems),,007007,Height,,,,Operational
+11,Single level report sequences (conventional data),311014,(Template for drifting balloon systems),,007007,Height,"shall be derived from some GNSS measurement",,,Operational
 11,Single level report sequences (conventional data),311014,(Template for drifting balloon systems),,033024,Station elevation quality mark (for mobile stations),,,,Operational
 11,Single level report sequences (conventional data),311014,(Template for drifting balloon systems),,008021,Time significance,= 2 Time averaged,,,Operational
 11,Single level report sequences (conventional data),311014,(Template for drifting balloon systems),,025170,Sampling interval (time),Seconds,,,Operational


### PR DESCRIPTION
This pull request contains a single commit (modification of BUFR_TableD_en_11.csv).
The modification adds a note relating to the use 0-07-007 element descriptor in the context of template 3-11-014 (drifting balloons).

This commit has been introduced on top of the branch 208-drifting-balloon-platforms.