### PR TITLE
208 drifting balloon platforms update

### DIFF
--- a/BUFRCREX_CodeFlag_en_01.csv
+++ b/BUFRCREX_CodeFlag_en_01.csv
@@ -367,10 +367,10 @@ FXY,ElementName_en,CodeFigure,EntryName_en,EntryName_sub1_en,EntryName_sub2_en,N
 001155,Retrieval identifier,7-254,Reserved,,,,,Operational
 001155,Retrieval identifier,255,Missing value,,,,,Operational
 001158,Type of balloon envelope,0,Reserved,,,,,Operational
-001158,Type of balloon envelope,1,SPB (Super-Pressurized Balloon) without altitude control,,,,,Operational
-001158,Type of balloon envelope,2,SPB (Super-Pressurized Balloon) with altitude control,,,,,Operational
-001158,Type of balloon envelope,3,ZPB (Zero-Pressure Balloon),,,,,Operational
-001158,Type of balloon envelope,4,IRM (Infra-Red Montgolfier),,,,,Operational
+001158,Type of balloon envelope,1,Super-Pressurized Balloon (SPB) without altitude control,,,,,Operational
+001158,Type of balloon envelope,2,SPB with altitude control,,,,,Operational
+001158,Type of balloon envelope,3,Zero-Pressure Balloon (ZPB),,,,,Operational
+001158,Type of balloon envelope,4,Infra-Red Montgolfier (IRM),,,,,Operational
 001158,Type of balloon envelope,5,Airship (Airship-shaped Balloon),,,,,Operational
-001158,Type of balloon envelope,6,Tetrodon (NOAA tetraedric Balloon),,,,,Operational
+001158,Type of balloon envelope,6,Tetroon (NOAA tetraedric Balloon),,,,,Operational
 001158,Type of balloon envelope,15,Missing value,,,,,Operational

--- a/BUFR_TableD_en_11.csv
+++ b/BUFR_TableD_en_11.csv
@@ -249,7 +249,7 @@ Category,CategoryOfSequences_en,FXY1,Title_en,SubTitle_en,FXY2,ElementName_en,El
 11,Single level report sequences (conventional data),311014,(Template for drifting balloon systems),,301011,"Year, month, day",,,,Operational
 11,Single level report sequences (conventional data),311014,(Template for drifting balloon systems),,301013,"Hour, minute, second",,,,Operational
 11,Single level report sequences (conventional data),311014,(Template for drifting balloon systems),,301021,Latitude/longitude (high accuracy),,,,Operational
-11,Single level report sequences (conventional data),311014,(Template for drifting balloon systems),,007007,Height,,,,Operational
+11,Single level report sequences (conventional data),311014,(Template for drifting balloon systems),,007007,Height,"shall be derived from some GNSS measurement",,,Operational
 11,Single level report sequences (conventional data),311014,(Template for drifting balloon systems),,033024,Station elevation quality mark (for mobile stations),,,,Operational
 11,Single level report sequences (conventional data),311014,(Template for drifting balloon systems),,008021,Time significance,= 2 Time averaged,,,Operational
 11,Single level report sequences (conventional data),311014,(Template for drifting balloon systems),,025170,Sampling interval (time),Seconds,,,Operational


### PR DESCRIPTION
An update on the BUFRCREX_CodeFlag_en_01.csv.

Update following an (forgotten) editorial suggestion by A. Milan, switching names and acronyms and correcting a typo on tetroons.

Alexis